### PR TITLE
Working Update for 10.0.17763.437 x64

### DIFF
--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -2,7 +2,7 @@
 ; Do not modify without special knowledge
 
 [Main]
-Updated=2019-08-02
+Updated=2019-09-02
 LogFile=\rdpwrap.txt
 SLPolicyHookNT60=1
 SLPolicyHookNT61=1
@@ -93,6 +93,104 @@ DefPolicyPatch.x64=1
 DefPolicyOffset.x64=65FF7
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
 
+[6.0.6001.22286]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=185E4
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=70DDE
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=17FD8
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=65C01
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
+[6.0.6001.22323]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=185E4
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=70DFA
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=17FD8
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=65C1D
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
+[6.0.6001.22357]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=185E4
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=70DFA
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=17FD8
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=65C1D
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
+[6.0.6001.22801]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=185F8
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=71ADA
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=18010
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=666AD
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
+[6.0.6002.22515]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=17FA8
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=71AFA
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=179C0
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=6675D
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
+[6.0.6002.22641]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=17FA8
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=71AFA
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=179C0
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=6675D
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
+[6.0.6002.22790]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=17FA8
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=71B02
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=179C0
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=66765
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
 [6.0.6002.23521]
 SingleUserPatch.x86=1
 SingleUserOffset.x86=17FB4
@@ -135,6 +233,20 @@ DefPolicyPatch.x64=1
 DefPolicyOffset.x64=17AD2
 DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
 
+[6.1.7600.20621]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=19E1D
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17DC2
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=196EB
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17ADE
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+
 [6.1.7600.20890]
 SingleUserPatch.x86=1
 SingleUserOffset.x86=19E2D
@@ -161,6 +273,20 @@ DefPolicyOffset.x86=196FB
 DefPolicyCode.x86=CDefPolicy_Query_eax_esi
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=17B5E
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+
+[6.1.7600.21420]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=19EF5
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17D56
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=19761
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17B3E
 DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
 
 [6.1.7601.17514]
@@ -247,6 +373,48 @@ DefPolicyPatch.x64=1
 DefPolicyOffset.x64=17D5E
 DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
 
+[6.1.7601.22213]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=1A5AD
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17F26
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=19DB1
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17D06
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+
+[6.1.7601.22435]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=1A5BD
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17F36
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=19DB1
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17D16
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+
+[6.1.7601.22476]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=1A5CD
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17F56
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=19DC1
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17D52
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+
 [6.1.7601.22750]
 SingleUserPatch.x86=1
 SingleUserOffset.x86=1A655
@@ -301,6 +469,20 @@ DefPolicyOffset.x86=19E41
 DefPolicyCode.x86=CDefPolicy_Query_eax_esi
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=17D2E
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+
+[6.1.7601.24326]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=1A675
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17F1E
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=19E41
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17CEE
 DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
 
 [6.1.7601.24402]
@@ -846,6 +1028,32 @@ SLInitOffset.x86=46581
 SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=250F0
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.10240.18036]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A7E18
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=96961
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=32715
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17264
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=2F299
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=EDC5
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=3F968
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=24C30
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.10240.18186]
@@ -1499,6 +1707,21 @@ SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=C920
 SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.14393.2608]
+; no x64 version
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A6248
+LocalOnlyCode.x86=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=36CE5
+SingleUserCode.x86=nop
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=31209
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+SLInitHook.x86=1
+SLInitOffset.x86=45824
+SLInitFunc.x86=New_CSLQuery_Initialize
 
 [10.0.14393.2906]
 LocalOnlyPatch.x86=1
@@ -3274,6 +3497,62 @@ SLInitHook.x64=1
 SLInitOffset.x64=1ABFC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.17763.168]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=AFC74
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=77AF1
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=4D665
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1322C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=4BE69
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17F45
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5B18A
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=1ABFC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.17763.288]
+; Patch CEnforcementCore::GetInstanceOfTSLicense
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=AFAD4
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=77A11
+LocalOnlyCode.x64=jmpshort
+; Patch CSessionArbitrationHelper::IsSingleSessionPerUserEnabled
+SingleUserPatch.x86=1
+SingleUserOffset.x86=4D665
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1322C
+SingleUserCode.x64=Zero
+; Patch CDefPolicy::Query
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=4BE69
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17F45
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+; Hook CSLQuery::Initialize
+SLInitHook.x86=1
+SLInitOffset.x86=5B18A
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=1ABFC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [10.0.17763.292]
 ; Patch CEnforcementCore::GetInstanceOfTSLicense
 LocalOnlyPatch.x86=1
@@ -3757,6 +4036,26 @@ bMultimonAllowed.x86  =C3F70
 bServerSku.x86        =C3F74
 ulMaxDebugSessions.x86=C3F78
 bRemoteConnAllowed.x86=C3F7C
+
+zlMaxUserSessions.x64 =F23B0
+lMaxUserSessions.x64  =F23B0
+bAppServerAllowed.x64 =F23B4
+bServerSku.x64        =F23B8
+bFUSEnabled.x64       =F3460
+bInitialized.x64      =F3464
+bMultimonAllowed.x64  =F3468
+ulMaxDebugSessions.x64=F346C
+bRemoteConnAllowed.x64=F3470
+
+[10.0.10240.18036-SLInit]
+bFUSEnabled.x86       =C3F88
+lMaxUserSessions.x86  =C3F8C
+bAppServerAllowed.x86 =C3F90
+bInitialized.x86      =C3F94
+bMultimonAllowed.x86  =C3F98
+bServerSku.x86        =C3F9C
+ulMaxDebugSessions.x86=C3FA0
+bRemoteConnAllowed.x86=C3FA4
 
 lMaxUserSessions.x64  =F23B0
 bAppServerAllowed.x64 =F23B4
@@ -4242,6 +4541,17 @@ bRemoteConnAllowed.x64=E8474
 bMultimonAllowed.x64  =E8478
 ulMaxDebugSessions.x64=E847C
 bFUSEnabled.x64       =E8480
+
+[10.0.14393.2608-SLInit]
+; no x64 version
+bInitialized.x86      =C1F94
+bServerSku.x86        =C1F98
+lMaxUserSessions.x86  =C1F9C
+bAppServerAllowed.x86 =C1FA0
+bRemoteConnAllowed.x86=C1FA4
+bMultimonAllowed.x86  =C1FA8
+ulMaxDebugSessions.x86=C1FAC
+bFUSEnabled.x86       =C1FB0
 
 [10.0.14393.2906-SLInit]
 bInitialized.x86      =C2F94
@@ -5531,6 +5841,44 @@ bFUSEnabled.x64       =ECAD0
 [10.0.17763.165-SLInit]
 bInitialized.x64      =ECAB0
 bServerSku.x64        =ECAB4
+lMaxUserSessions.x64  =ECAB8
+bAppServerAllowed.x64 =ECAC0
+bRemoteConnAllowed.x64=ECAC4
+bMultimonAllowed.x64  =ECAC8
+ulMaxDebugSessions.x64=ECACC
+bFUSEnabled.x64       =ECAD0
+
+[10.0.17763.168-SLInit]
+bInitialized.x86      =CD798
+bServerSku.x86        =CD79C
+lMaxUserSessions.x86  =CD7A0
+bAppServerAllowed.x86 =CD7A8
+bRemoteConnAllowed.x86=CD7AC
+bMultimonAllowed.x86  =CD7B0
+ulMaxDebugSessions.x86=CD7B4
+bFUSEnabled.x86       =CD7B8
+
+bInitialized.x64      =ECAB0
+bServerSku.x64        =ECAB4
+lMaxUserSessions.x64  =ECAB8
+bAppServerAllowed.x64 =ECAC0
+bRemoteConnAllowed.x64=ECAC4
+bMultimonAllowed.x64  =ECAC8
+ulMaxDebugSessions.x64=ECACC
+bFUSEnabled.x64       =ECAD0
+
+[10.0.17763.288-SLInit]
+bInitialized.x86      =CD798
+bServerSku.x86        =CD79C
+lMaxUserSessions.x86  =CD7A0
+bAppServerAllowed.x86 =CD7A8
+bRemoteConnAllowed.x86=CD7AC
+bMultimonAllowed.x86  =CD7B0
+ulMaxDebugSessions.x86=CD7B4
+bFUSEnabled.x86       =CD7B8
+
+bInitialized.x64 =ECAB0
+bServerSku.x64 =ECAB4
 lMaxUserSessions.x64  =ECAB8
 bAppServerAllowed.x64 =ECAC0
 bRemoteConnAllowed.x64=ECAC4

--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -3638,14 +3638,6 @@ SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=1ACDC
 SLInitFunc.x64=New_CSLQuery_Initialize
-bInitialized.x64 =ECAB0
-bServerSku.x64 =ECAB4
-lMaxUserSessions.x64 =ECAB8
-bAppServerAllowed.x64 =ECAC0
-bRemoteConnAllowed.x64=ECAC4
-bMultimonAllowed.x64 =ECAC8
-ulMaxDebugSessions.x64=ECACC
-bFUSEnabled.x64 =ECAD0
 
 [10.0.17134.706]
 LocalOnlyPatch.x86=1

--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -2,7 +2,7 @@
 ; Do not modify without special knowledge
 
 [Main]
-Updated=2018-10-10
+Updated=2019-04-19
 LogFile=\rdpwrap.txt
 SLPolicyHookNT60=1
 SLPolicyHookNT61=1
@@ -105,6 +105,20 @@ DefPolicyOffset.x86=179CC
 DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=669CB
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
+[6.0.6003.20482]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=17FC4
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=71F8A
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=179DC
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=66B65
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
 
 [6.1.7600.16385]
@@ -289,6 +303,20 @@ DefPolicyPatch.x64=1
 DefPolicyOffset.x64=17D2E
 DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
 
+[6.1.7601.24402]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=1A675
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17F26
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=19E41
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17CFE
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+
 [6.2.8102.0]
 SingleUserPatch.x86=1
 SingleUserOffset.x86=F7E9
@@ -407,6 +435,27 @@ SLPolicyOffset.x86=19581
 SLPolicyFunc.x86=New_Win8SL
 SLPolicyInternal.x64=1
 SLPolicyOffset.x64=21FD0
+SLPolicyFunc.x64=New_Win8SL
+
+[6.2.9200.22715]
+; x86-Offsets are not safe (determined without symbols)
+SingleUserPatch.x86=1
+SingleUserOffset.x86=155B2
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=2BAE4
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=13F68
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=2A396
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+SLPolicyInternal.x86=1
+SLPolicyOffset.x86=195B9
+SLPolicyFunc.x86=New_Win8SL
+SLPolicyInternal.x64=1
+SLPolicyOffset.x64=21F90
 SLPolicyFunc.x64=New_Win8SL
 
 [6.3.9431.0]
@@ -617,6 +666,32 @@ SLInitHook.x64=1
 SLInitOffset.x64=5D660
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[6.3.9600.19318]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B43E8
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=89EAC
+LocalOnlyCode.x64=nopjmp
+SingleUserPatch.x86=1
+SingleUserOffset.x86=3ED25
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=35779
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=3D579
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=43CE5
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=180F8
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=5C0D0
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [6.4.9841.0]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=956A8
@@ -771,6 +846,32 @@ SLInitOffset.x86=46581
 SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=250F0
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.10240.18186]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A8048
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=96A41
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=32B15
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17264
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=2F699
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=EDC5
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=3FA58
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=249D0
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.10586.0]
@@ -1397,6 +1498,32 @@ SLInitOffset.x86=45824
 SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=C920
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.14393.2906]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A6578
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=8D8A1
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=36CE5
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1B6A4
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=31209
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=F185
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=45912
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22C80
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.14901.1000]
@@ -2157,6 +2284,32 @@ SLInitHook.x64=1
 SLInitOffset.x64=234DC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.15063.1746]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A60D8
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=8CB21
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=35CA5
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=15EA4
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=30999
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=FAE5
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=3F94D
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=2328C
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [10.0.16179.1000]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=AA568
@@ -2703,6 +2856,32 @@ SLInitHook.x64=1
 SLInitOffset.x64=22D5C
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.16299.1087]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A91F8
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=8FC11
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=392E5
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1C774
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=3DD39
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=12D85
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=4626D
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22E4C
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [10.0.16353.1000]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=A9388
@@ -3015,6 +3194,46 @@ SLInitHook.x64=1
 SLInitOffset.x64=22E6C
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.17763.437]
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=77A41
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x64=1
+SingleUserOffset.x64=3E520
+SingleUserCode.x64=Zero
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=18025
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x64=1
+SLInitOffset.x64=1ACDC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.17134.706]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=ADAB8
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=92521
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=36B1C
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1511C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=33579
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=10E78
+DefPolicyCode.x64=CDefPolicy_Query_edi_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=475DD
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22F5C
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [10.0.17723.1000]
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=75D91
@@ -3053,6 +3272,152 @@ SLInitOffset.x86=5B02A
 SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=1ABFC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.17763.165]
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=77941
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x64=1
+SingleUserOffset.x64=132F9
+SingleUserCode.x64=Zero
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17F45
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x64=1
+SLInitOffset.x64=1ABFC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.17763.292]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=AFAD4
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=77A11
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=4D665
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1322C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=4BE69
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17F45
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5B18A
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=1ABFC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.17763.379]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=AFAD4
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=77A11
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=4D665
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1322C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=4BE69
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17F45
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5B18A
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=1ABFC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.17763.437]
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=77A41
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1322C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=18025
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x64=1
+SLInitOffset.x64=1ACDC
+SLInitFunc.x64=New_CSLQuery_Initialize
+bInitialized.x64 =ECAB0
+bServerSku.x64 =ECAB4
+lMaxUserSessions.x64 =ECAB8
+bAppServerAllowed.x64 =ECAC0
+bRemoteConnAllowed.x64=ECAC4
+bMultimonAllowed.x64 =ECAC8
+ulMaxDebugSessions.x64=ECACC
+bFUSEnabled.x64 =ECAD0
+
+[10.0.17763.437-SLInit]
+bInitialized.x86 =CD798
+bServerSku.x86 =CD79C
+lMaxUserSessions.x86 =CD7A0
+bAppServerAllowed.x86 =CD7A8
+bRemoteConnAllowed.x86=CD7AC
+bMultimonAllowed.x86 =CD7B0
+ulMaxDebugSessions.x86=CD7B4
+bFUSEnabled.x86 =CD7B8
+bInitialized.x64 =ECAB0
+bServerSku.x64 =ECAB4
+lMaxUserSessions.x64 =ECAB8
+bAppServerAllowed.x64 =ECAC0
+bRemoteConnAllowed.x64=ECAC4
+bMultimonAllowed.x64 =ECAC8
+ulMaxDebugSessions.x64=ECACC
+bFUSEnabled.x64 =ECAD0
+
+[10.0.17134.706]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=ADAB8
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=92521
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=36B1C
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1511C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=33579
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=10E78
+DefPolicyCode.x64=CDefPolicy_Query_edi_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=475DD
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22F5C
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.18362.1]
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=82F35
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x64=1
+SingleUserOffset.x64=0DDC9
+SingleUserCode.x64=Zero
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=1FE05
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x64=1
+SLInitOffset.x64=22DCC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [SLInit]
@@ -3217,6 +3582,25 @@ bServerSku.x64        =FA068
 ulMaxDebugSessions.x64=FA06C
 bRemoteConnAllowed.x64=FA070
 
+[6.3.9600.19318-SLInit]
+bFUSEnabled.x86       =D4068
+lMaxUserSessions.x86  =D406C
+bAppServerAllowed.x86 =D4070
+bInitialized.x86      =D4074
+bMultimonAllowed.x86  =D4078
+bServerSku.x86        =D407C
+ulMaxDebugSessions.x86=D4080
+bRemoteConnAllowed.x86=D4084
+
+bFUSEnabled.x64       =FA054
+lMaxUserSessions.x64  =FA058
+bAppServerAllowed.x64 =FA05C
+bInitialized.x64      =FA060
+bMultimonAllowed.x64  =FA064
+bServerSku.x64        =FA068
+ulMaxDebugSessions.x64=FA06C
+bRemoteConnAllowed.x64=FA070
+
 [6.4.9841.0-SLInit]
 bFUSEnabled.x86       =BF9F0
 lMaxUserSessions.x86  =BF9F4
@@ -3321,6 +3705,25 @@ bMultimonAllowed.x86  =C3F70
 bServerSku.x86        =C3F74
 ulMaxDebugSessions.x86=C3F78
 bRemoteConnAllowed.x86=C3F7C
+
+lMaxUserSessions.x64  =F23B0
+bAppServerAllowed.x64 =F23B4
+bServerSku.x64        =F23B8
+bFUSEnabled.x64       =F3460
+bInitialized.x64      =F3464
+bMultimonAllowed.x64  =F3468
+ulMaxDebugSessions.x64=F346C
+bRemoteConnAllowed.x64=F3470
+
+[10.0.10240.18186-SLInit]
+bFUSEnabled.x86       =C4F88
+lMaxUserSessions.x86  =C4F8C
+bAppServerAllowed.x86 =C4F90
+bInitialized.x86      =C4F94
+bMultimonAllowed.x86  =C4F98
+bServerSku.x86        =C4F9C
+ulMaxDebugSessions.x86=C4FA0
+bRemoteConnAllowed.x86=C4FA4
 
 lMaxUserSessions.x64  =F23B0
 bAppServerAllowed.x64 =F23B4
@@ -3778,6 +4181,25 @@ bRemoteConnAllowed.x86=C1FA4
 bMultimonAllowed.x86  =C1FA8
 ulMaxDebugSessions.x86=C1FAC
 bFUSEnabled.x86       =C1FB0
+
+bServerSku.x64        =E73D0
+lMaxUserSessions.x64  =E73D4
+bAppServerAllowed.x64 =E73D8
+bInitialized.x64      =E8470
+bRemoteConnAllowed.x64=E8474
+bMultimonAllowed.x64  =E8478
+ulMaxDebugSessions.x64=E847C
+bFUSEnabled.x64       =E8480
+
+[10.0.14393.2906-SLInit]
+bInitialized.x86      =C2F94
+bServerSku.x86        =C2F98
+lMaxUserSessions.x86  =C2F9C
+bAppServerAllowed.x86 =C2FA0
+bRemoteConnAllowed.x86=C2FA4
+bMultimonAllowed.x86  =C2FA8
+ulMaxDebugSessions.x86=C2FAC
+bFUSEnabled.x86       =C2FB0
 
 bServerSku.x64        =E73D0
 lMaxUserSessions.x64  =E73D4
@@ -4341,6 +4763,25 @@ bServerSku.x64        =E9484
 lMaxUserSessions.x64  =E9488
 bAppServerAllowed.x64 =E948C
 
+[10.0.15063.1746-SLInit]
+bInitialized.x86      =C3F98
+bServerSku.x86        =C3F9C
+lMaxUserSessions.x86  =C3FA0
+bAppServerAllowed.x86 =C3FA4
+bRemoteConnAllowed.x86=C3FA8
+bMultimonAllowed.x86  =C3FAC
+ulMaxDebugSessions.x86=C3FB0
+bFUSEnabled.x86       =C3FB4
+
+bInitialized.x64      =E9468
+bRemoteConnAllowed.x64=E946C
+bMultimonAllowed.x64  =E9470
+ulMaxDebugSessions.x64=E9474
+bFUSEnabled.x64       =E9478
+bServerSku.x64        =E9484
+lMaxUserSessions.x64  =E9488
+bAppServerAllowed.x64 =E948C
+
 [10.0.16179.1000-SLInit]
 bInitialized.x86      =C7F6C
 bServerSku.x86        =C7F70
@@ -4740,6 +5181,25 @@ bMultimonAllowed.x64  =EE4A8
 ulMaxDebugSessions.x64=EE4AC
 bFUSEnabled.x64       =EE4B0
 
+[10.0.16299.1087-SLInit]
+bInitialized.x86      =C6F7C
+bServerSku.x86        =C6F80
+lMaxUserSessions.x86  =C6F84
+bAppServerAllowed.x86 =C6F88
+bRemoteConnAllowed.x86=C6F8C
+bMultimonAllowed.x86  =C6F90
+ulMaxDebugSessions.x86=C6F94
+bFUSEnabled.x86       =C6F98
+
+bServerSku.x64        =ED3E8
+lMaxUserSessions.x64  =ED3EC
+bAppServerAllowed.x64 =ED3F0
+bInitialized.x64      =EE4A0
+bRemoteConnAllowed.x64=EE4A4
+bMultimonAllowed.x64  =EE4A8
+ulMaxDebugSessions.x64=EE4AC
+bFUSEnabled.x64       =EE4B0
+
 [10.0.16353.1000-SLInit]
 bInitialized.x86      =C6F7C
 bServerSku.x86        =C6F80
@@ -4968,6 +5428,25 @@ bMultimonAllowed.x64  =F2438
 ulMaxDebugSessions.x64=F243C
 bFUSEnabled.x64       =F2440
 
+[10.0.17134.706-SLInit]
+bInitialized.x86      =CBF38
+bServerSku.x86        =CBF3C
+lMaxUserSessions.x86  =CBF40
+bAppServerAllowed.x86 =CBF44
+bRemoteConnAllowed.x86=CBF48
+bMultimonAllowed.x86  =CBF4C
+ulMaxDebugSessions.x86=CBF50
+bFUSEnabled.x86       =CBF54
+
+bServerSku.x64        =F1378
+lMaxUserSessions.x64  =F137C
+bAppServerAllowed.x64 =F1380
+bInitialized.x64      =F2430
+bRemoteConnAllowed.x64=F2434
+bMultimonAllowed.x64  =F2438
+ulMaxDebugSessions.x64=F243C
+bFUSEnabled.x64       =F2440
+
 [10.0.17723.1000-SLInit]
 bInitialized.x64      =E9AB0
 bServerSku.x64        =E9AB4
@@ -4996,3 +5475,99 @@ bRemoteConnAllowed.x64=ECAC4
 bMultimonAllowed.x64  =ECAC8
 ulMaxDebugSessions.x64=ECACC
 bFUSEnabled.x64       =ECAD0
+
+[10.0.17763.165-SLInit]
+bInitialized.x64 =ECAB0
+bServerSku.x64 =ECAB4
+lMaxUserSessions.x64 =ECAB8
+bAppServerAllowed.x64 =ECAC0
+bRemoteConnAllowed.x64=ECAC4
+bMultimonAllowed.x64 =ECAC8
+ulMaxDebugSessions.x64=ECACC
+bFUSEnabled.x64 =ECAD0
+
+[10.0.17763.292-SLInit]
+bInitialized.x86 =CD798
+bServerSku.x86 =CD79C
+lMaxUserSessions.x86 =CD7A0
+bAppServerAllowed.x86 =CD7A8
+bRemoteConnAllowed.x86=CD7AC
+bMultimonAllowed.x86 =CD7B0
+ulMaxDebugSessions.x86=CD7B4
+bFUSEnabled.x86 =CD7B8
+
+bInitialized.x64 =ECAB0
+bServerSku.x64 =ECAB4
+lMaxUserSessions.x64 =ECAB8
+bAppServerAllowed.x64 =ECAC0
+bRemoteConnAllowed.x64=ECAC4
+bMultimonAllowed.x64 =ECAC8
+ulMaxDebugSessions.x64=ECACC
+bFUSEnabled.x64 =ECAD0
+
+[10.0.17763.379-SLInit]
+bInitialized.x86 =CD798
+bServerSku.x86 =CD79C
+lMaxUserSessions.x86 =CD7A0
+bAppServerAllowed.x86 =CD7A8
+bRemoteConnAllowed.x86=CD7AC
+bMultimonAllowed.x86 =CD7B0
+ulMaxDebugSessions.x86=CD7B4
+bFUSEnabled.x86 =CD7B8
+
+bInitialized.x64 =ECAB0
+bServerSku.x64 =ECAB4
+lMaxUserSessions.x64 =ECAB8
+bAppServerAllowed.x64 =ECAC0
+bRemoteConnAllowed.x64=ECAC4
+bMultimonAllowed.x64 =ECAC8
+ulMaxDebugSessions.x64=ECACC
+bFUSEnabled.x64 =ECAD0
+
+[10.0.17763.437-SLInit]
+bInitialized.x86 =CD798
+bServerSku.x86 =CD79C
+lMaxUserSessions.x86 =CD7A0
+bAppServerAllowed.x86 =CD7A8
+bRemoteConnAllowed.x86=CD7AC
+bMultimonAllowed.x86 =CD7B0
+ulMaxDebugSessions.x86=CD7B4
+bFUSEnabled.x86 =CD7B8
+
+bInitialized.x64 =ECAB0
+bServerSku.x64 =ECAB4
+lMaxUserSessions.x64 =ECAB8
+bAppServerAllowed.x64 =ECAC0
+bRemoteConnAllowed.x64=ECAC4
+bMultimonAllowed.x64 =ECAC8
+ulMaxDebugSessions.x64=ECACC
+bFUSEnabled.x64 =ECAD0
+
+[10.0.17134.706-SLInit]
+bInitialized.x86      =CBF38
+bServerSku.x86        =CBF3C
+lMaxUserSessions.x86  =CBF40
+bAppServerAllowed.x86 =CBF44
+bRemoteConnAllowed.x86=CBF48
+bMultimonAllowed.x86  =CBF4C
+ulMaxDebugSessions.x86=CBF50
+bFUSEnabled.x86       =CBF54
+
+bServerSku.x64        =F1378
+lMaxUserSessions.x64  =F137C
+bAppServerAllowed.x64 =F1380
+bInitialized.x64      =F2430
+bRemoteConnAllowed.x64=F2434
+bMultimonAllowed.x64  =F2438
+ulMaxDebugSessions.x64=F243C
+bFUSEnabled.x64       =F2440
+
+[10.0.18362.1-SLInit]
+bInitialized.x64 =F6A8C
+bServerSku.x64 =F6A90
+lMaxUserSessions.x64 =F6A94
+bAppServerAllowed.x64 =F6A9C
+bRemoteConnAllowed.x64=F6AA0
+bMultimonAllowed.x64 =F6AA4
+ulMaxDebugSessions.x64=F6AA8
+bFUSEnabled.x64 =F6AAC

--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -3331,36 +3331,22 @@ SLInitOffset.x64=1ABFC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.17763.437]
+; Patch CEnforcementCore::GetInstanceOfTSLicense
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=77A41
 LocalOnlyCode.x64=jmpshort
+; Patch CSessionArbitrationHelper::IsSingleSessionPerUserEnabled
 SingleUserPatch.x64=1
 SingleUserOffset.x64=1322C
 SingleUserCode.x64=Zero
+; Patch CDefPolicy::Query
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=18025
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+; Hook CSLQuery::Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=1ACDC
 SLInitFunc.x64=New_CSLQuery_Initialize
-bInitialized.x64 =ECAB0
-bServerSku.x64 =ECAB4
-lMaxUserSessions.x64 =ECAB8
-bAppServerAllowed.x64 =ECAC0
-bRemoteConnAllowed.x64=ECAC4
-bMultimonAllowed.x64 =ECAC8
-ulMaxDebugSessions.x64=ECACC
-bFUSEnabled.x64 =ECAD0
-
-[10.0.17763.437-SLInit]
-bInitialized.x86 =CD798
-bServerSku.x86 =CD79C
-lMaxUserSessions.x86 =CD7A0
-bAppServerAllowed.x86 =CD7A8
-bRemoteConnAllowed.x86=CD7AC
-bMultimonAllowed.x86 =CD7B0
-ulMaxDebugSessions.x86=CD7B4
-bFUSEnabled.x86 =CD7B8
 bInitialized.x64 =ECAB0
 bServerSku.x64 =ECAB4
 lMaxUserSessions.x64 =ECAB8

--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -3194,20 +3194,6 @@ SLInitHook.x64=1
 SLInitOffset.x64=22E6C
 SLInitFunc.x64=New_CSLQuery_Initialize
 
-[10.0.17763.437]
-LocalOnlyPatch.x64=1
-LocalOnlyOffset.x64=77A41
-LocalOnlyCode.x64=jmpshort
-SingleUserPatch.x64=1
-SingleUserOffset.x64=3E520
-SingleUserCode.x64=Zero
-DefPolicyPatch.x64=1
-DefPolicyOffset.x64=18025
-DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
-SLInitHook.x64=1
-SLInitOffset.x64=1ACDC
-SLInitFunc.x64=New_CSLQuery_Initialize
-
 [10.0.17134.706]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=ADAB8
@@ -3289,24 +3275,28 @@ SLInitOffset.x64=1ABFC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.17763.292]
+; Patch CEnforcementCore::GetInstanceOfTSLicense
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=AFAD4
 LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=77A11
 LocalOnlyCode.x64=jmpshort
+; Patch CSessionArbitrationHelper::IsSingleSessionPerUserEnabled
 SingleUserPatch.x86=1
 SingleUserOffset.x86=4D665
 SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=1322C
 SingleUserCode.x64=Zero
+; Patch CDefPolicy::Query
 DefPolicyPatch.x86=1
 DefPolicyOffset.x86=4BE69
 DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=17F45
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+; Hook CSLQuery::Initialize
 SLInitHook.x86=1
 SLInitOffset.x86=5B18A
 SLInitFunc.x86=New_CSLQuery_Initialize

--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -2,7 +2,7 @@
 ; Do not modify without special knowledge
 
 [Main]
-Updated=2019-04-19
+Updated=2019-08-02
 LogFile=\rdpwrap.txt
 SLPolicyHookNT60=1
 SLPolicyHookNT61=1
@@ -3332,18 +3332,30 @@ SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.17763.437]
 ; Patch CEnforcementCore::GetInstanceOfTSLicense
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=AFE24
+LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=77A41
 LocalOnlyCode.x64=jmpshort
 ; Patch CSessionArbitrationHelper::IsSingleSessionPerUserEnabled
+SingleUserPatch.x86=1
+SingleUserOffset.x86=4D7B5
+SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=1322C
 SingleUserCode.x64=Zero
 ; Patch CDefPolicy::Query
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=4BFB9
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=18025
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
 ; Hook CSLQuery::Initialize
+SLInitHook.x86=1
+SLInitOffset.x86=5B2CA
+SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=1ACDC
 SLInitFunc.x64=New_CSLQuery_Initialize
@@ -3383,17 +3395,81 @@ SLInitOffset.x64=22F5C
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.18362.1]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B7A16
+LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=82F35
 LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=50515
+SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=0DDC9
 SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=50249
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=1FE05
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5A75A
+SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=22DCC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.18362.53]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B7D06
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=82FB5
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=50535
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=0DBFC
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=50269
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=1FE15
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5A77A
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22DDC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.18362.267]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B7D06
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=82FB5
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=50535
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=0DBFC
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=50269
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=1FE15
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5A77A
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22DDC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [SLInit]
@@ -5453,71 +5529,71 @@ ulMaxDebugSessions.x64=ECACC
 bFUSEnabled.x64       =ECAD0
 
 [10.0.17763.165-SLInit]
-bInitialized.x64 =ECAB0
-bServerSku.x64 =ECAB4
-lMaxUserSessions.x64 =ECAB8
+bInitialized.x64      =ECAB0
+bServerSku.x64        =ECAB4
+lMaxUserSessions.x64  =ECAB8
 bAppServerAllowed.x64 =ECAC0
 bRemoteConnAllowed.x64=ECAC4
-bMultimonAllowed.x64 =ECAC8
+bMultimonAllowed.x64  =ECAC8
 ulMaxDebugSessions.x64=ECACC
-bFUSEnabled.x64 =ECAD0
+bFUSEnabled.x64       =ECAD0
 
 [10.0.17763.292-SLInit]
-bInitialized.x86 =CD798
-bServerSku.x86 =CD79C
-lMaxUserSessions.x86 =CD7A0
+bInitialized.x86      =CD798
+bServerSku.x86        =CD79C
+lMaxUserSessions.x86  =CD7A0
 bAppServerAllowed.x86 =CD7A8
 bRemoteConnAllowed.x86=CD7AC
-bMultimonAllowed.x86 =CD7B0
+bMultimonAllowed.x86  =CD7B0
 ulMaxDebugSessions.x86=CD7B4
-bFUSEnabled.x86 =CD7B8
+bFUSEnabled.x86       =CD7B8
 
-bInitialized.x64 =ECAB0
-bServerSku.x64 =ECAB4
-lMaxUserSessions.x64 =ECAB8
+bInitialized.x64      =ECAB0
+bServerSku.x64        =ECAB4
+lMaxUserSessions.x64  =ECAB8
 bAppServerAllowed.x64 =ECAC0
 bRemoteConnAllowed.x64=ECAC4
-bMultimonAllowed.x64 =ECAC8
+bMultimonAllowed.x64  =ECAC8
 ulMaxDebugSessions.x64=ECACC
-bFUSEnabled.x64 =ECAD0
+bFUSEnabled.x64       =ECAD0
 
 [10.0.17763.379-SLInit]
-bInitialized.x86 =CD798
-bServerSku.x86 =CD79C
-lMaxUserSessions.x86 =CD7A0
+bInitialized.x86      =CD798
+bServerSku.x86        =CD79C
+lMaxUserSessions.x86  =CD7A0
 bAppServerAllowed.x86 =CD7A8
 bRemoteConnAllowed.x86=CD7AC
-bMultimonAllowed.x86 =CD7B0
+bMultimonAllowed.x86  =CD7B0
 ulMaxDebugSessions.x86=CD7B4
-bFUSEnabled.x86 =CD7B8
+bFUSEnabled.x86       =CD7B8
 
-bInitialized.x64 =ECAB0
-bServerSku.x64 =ECAB4
-lMaxUserSessions.x64 =ECAB8
+bInitialized.x64      =ECAB0
+bServerSku.x64        =ECAB4
+lMaxUserSessions.x64  =ECAB8
 bAppServerAllowed.x64 =ECAC0
 bRemoteConnAllowed.x64=ECAC4
-bMultimonAllowed.x64 =ECAC8
+bMultimonAllowed.x64  =ECAC8
 ulMaxDebugSessions.x64=ECACC
-bFUSEnabled.x64 =ECAD0
+bFUSEnabled.x64       =ECAD0
 
 [10.0.17763.437-SLInit]
-bInitialized.x86 =CD798
-bServerSku.x86 =CD79C
-lMaxUserSessions.x86 =CD7A0
+bInitialized.x86      =CD798
+bServerSku.x86        =CD79C
+lMaxUserSessions.x86  =CD7A0
 bAppServerAllowed.x86 =CD7A8
 bRemoteConnAllowed.x86=CD7AC
-bMultimonAllowed.x86 =CD7B0
+bMultimonAllowed.x86  =CD7B0
 ulMaxDebugSessions.x86=CD7B4
-bFUSEnabled.x86 =CD7B8
+bFUSEnabled.x86       =CD7B8
 
-bInitialized.x64 =ECAB0
-bServerSku.x64 =ECAB4
-lMaxUserSessions.x64 =ECAB8
+bInitialized.x64      =ECAB0
+bServerSku.x64        =ECAB4
+lMaxUserSessions.x64  =ECAB8
 bAppServerAllowed.x64 =ECAC0
 bRemoteConnAllowed.x64=ECAC4
-bMultimonAllowed.x64 =ECAC8
+bMultimonAllowed.x64  =ECAC8
 ulMaxDebugSessions.x64=ECACC
-bFUSEnabled.x64 =ECAD0
+bFUSEnabled.x64       =ECAD0
 
 [10.0.17134.706-SLInit]
 bInitialized.x86      =CBF38
@@ -5539,11 +5615,58 @@ ulMaxDebugSessions.x64=F243C
 bFUSEnabled.x64       =F2440
 
 [10.0.18362.1-SLInit]
-bInitialized.x64 =F6A8C
-bServerSku.x64 =F6A90
-lMaxUserSessions.x64 =F6A94
+bInitialized.x86      =D477C
+bServerSku.x86        =D4780
+lMaxUserSessions.x86  =D4784
+bAppServerAllowed.x86 =D478C
+bRemoteConnAllowed.x86=D4790
+bMultimonAllowed.x86  =D4794
+ulMaxDebugSessions.x86=D4798
+bFUSEnabled.x86       =D479C
+
+bInitialized.x64      =F6A8C
+bServerSku.x64        =F6A90
+lMaxUserSessions.x64  =F6A94
 bAppServerAllowed.x64 =F6A9C
 bRemoteConnAllowed.x64=F6AA0
-bMultimonAllowed.x64 =F6AA4
+bMultimonAllowed.x64  =F6AA4
 ulMaxDebugSessions.x64=F6AA8
-bFUSEnabled.x64 =F6AAC
+bFUSEnabled.x64       =F6AAC
+
+[10.0.18362.53-SLInit]
+bInitialized.x86      =D577C
+bServerSku.x86        =D5780
+lMaxUserSessions.x86  =D5784
+bAppServerAllowed.x86 =D578C
+bRemoteConnAllowed.x86=D5790
+bMultimonAllowed.x86  =D5794
+ulMaxDebugSessions.x86=D5798
+bFUSEnabled.x86       =D579C
+
+bInitialized.x64      =F6A8C
+bServerSku.x64        =F6A90
+lMaxUserSessions.x64  =F6A94
+bAppServerAllowed.x64 =F6A9C
+bRemoteConnAllowed.x64=F6AA0
+bMultimonAllowed.x64  =F6AA4
+ulMaxDebugSessions.x64=F6AA8
+bFUSEnabled.x64       =F6AAC
+
+[10.0.18362.267-SLInit]
+bInitialized.x86      =D577C
+bServerSku.x86        =D5780
+lMaxUserSessions.x86  =D5784
+bAppServerAllowed.x86 =D578C
+bRemoteConnAllowed.x86=D5790
+bMultimonAllowed.x86  =D5794
+ulMaxDebugSessions.x86=D5798
+bFUSEnabled.x86       =D579C
+
+bInitialized.x64      =F6A8C
+bServerSku.x64        =F6A90
+lMaxUserSessions.x64  =F6A94
+bAppServerAllowed.x64 =F6A9C
+bRemoteConnAllowed.x64=F6AA0
+bMultimonAllowed.x64  =F6AA4
+ulMaxDebugSessions.x64=F6AA8
+bFUSEnabled.x64       =F6AAC


### PR DESCRIPTION
### description
This the `rdpwrap.ini` that is tested and working on 10.0.17763.437 x64 (Windows Server 2019 build 1809 17763.615)

### changes
- Removed the `[10.0.17763.437]` and `[10.0.17763.437-SLInit]` duplicated entries
- Added some comments

Also, @zhangyoufu's suggested `SingleUserOffset.x64=13469` instead of `SingleUserOffset.x64=1322C` (see [here](https://gist.github.com/zhangyoufu/4c5fdc193f4513f5c3cd0ff94497d73f))

### added x86 (32bit) for builds
- `[10.0.17763.437]`
- `[10.0.18362.1]`

### builds with conflicting offset values
#### `[10.0.17763.165]`
|  current | alt |
| --- | --- |
| SingleUserOffset.x64=132F9 | SingleUserOffset.x64=1322C |

**note:** `1322C` seems to be correct.
#### `[10.0.17763.437]`
|  **correct**| current |
| --- | --- |
| SingleUserOffset.x64=1322C | SingleUserOffset.x64=1339C |

**note:** `1322C` seems to be correct.
- source: https://github.com/stascorp/rdpwrap/pull/725/files#r292265309
- confirmation: https://github.com/stascorp/rdpwrap/issues/729#issuecomment-482609476

### missing builds

- `[6.0.6001.22286]`
- `[6.0.6001.22323]`
- `[6.0.6001.22357]`
- `[6.0.6001.22801]`
- `[6.0.6002.22515]`
- `[6.0.6002.22641]`
- `[6.0.6002.22790]`
- `[6.0.6003.20482]`
- `[6.1.7600.20621]`
- `[6.1.7600.21420]`
- `[6.1.7601.22213]`
- `[6.1.7601.22435]`
- `[6.1.7601.22476]`
- `[6.1.7601.24326]`
- `[6.1.7601.24402]`
- `[6.2.9200.22715]`
- `[6.3.9600.19318]`
- `[10.0.10240.18036]`
- `[10.0.10240.18186]`
- `[10.0.14393.2608]`
- `[10.0.14393.2906]`
- `[10.0.15063.1746]`
- `[10.0.16299.1087]`
- `[10.0.17134.706]`
- `[10.0.17763.165]`
- `[10.0.17763.168]`
- `[10.0.17763.288]`
- `[10.0.17763.292]`
- `[10.0.17763.379]`
- `[10.0.17763.437]`
- `[10.0.18362.1]`
- `[10.0.18362.267]`
- `[10.0.18362.53]`